### PR TITLE
[OpenATVstatus] update 2.4

### DIFF
--- a/po/OpenATVstatus.pot
+++ b/po/OpenATVstatus.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-13 19:29+0100\n"
+"POT-Creation-Date: 2024-04-26 10:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,214 +14,238 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "latest available version"
 msgstr ""
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "oldest available version"
 msgstr ""
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "faster"
 msgstr ""
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "normal"
 msgstr ""
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "off"
 msgstr ""
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "slower"
 msgstr ""
 
-#: ..\plugin.py:56
+#: ..\plugin.py:57
 msgid "selected box"
 msgstr ""
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "absolute time"
 msgstr ""
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "relative time"
 msgstr ""
 
-#: ..\plugin.py:186
+#: ..\plugin.py:59
+msgid "local time (this box)"
+msgstr ""
+
+#: ..\plugin.py:59
+msgid "server time (UTC)"
+msgstr ""
+
+#: ..\plugin.py:206
 msgid "Favorites"
 msgstr ""
 
-#: ..\plugin.py:194 ..\plugin.py:522
+#: ..\plugin.py:214 ..\plugin.py:545
 msgid "remove box from favorites"
 msgstr ""
 
-#: ..\plugin.py:195 ..\plugin.py:441
+#: ..\plugin.py:215 ..\plugin.py:462
 msgid "Images list"
 msgstr ""
 
-#: ..\plugin.py:196 ..\plugin.py:461 ..\plugin.py:661
+#: ..\plugin.py:216 ..\plugin.py:483 ..\plugin.py:687
 msgid "Boxdetails"
 msgstr ""
 
-#: ..\plugin.py:197 ..\plugin.py:462 ..\plugin.py:746
+#: ..\plugin.py:217 ..\plugin.py:484 ..\plugin.py:772
 msgid "Settings"
 msgstr ""
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "No favorites (box, platform) set yet."
 msgstr ""
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "Please select favorite(s) in the image lists."
 msgstr ""
 
-#: ..\plugin.py:354 ..\plugin.py:356
+#: ..\plugin.py:375 ..\plugin.py:377
 msgid "platform"
 msgstr ""
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "boxes"
 msgstr ""
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "failed"
 msgstr ""
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "last build cycle"
 msgstr ""
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "invalid"
 msgstr ""
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "unclear"
 msgstr ""
 
-#: ..\plugin.py:365 ..\plugin.py:586
+#: ..\plugin.py:386 ..\plugin.py:609
 msgid "Box '%s-%s' was sucessfully removed from favorites!"
 msgstr ""
 
-#: ..\plugin.py:377 ..\plugin.py:593
+#: ..\plugin.py:398 ..\plugin.py:616
 msgid "Do you really want to remove Box '%s-%s' from favorites?"
 msgstr ""
 
-#: ..\plugin.py:459
+#: ..\plugin.py:481
 msgid "jump to construction site"
 msgstr ""
 
-#: ..\plugin.py:460
+#: ..\plugin.py:482
 msgid "jump to favorite(s)"
 msgstr ""
 
-#: ..\plugin.py:486
+#: ..\plugin.py:508
 msgid "previous"
 msgstr ""
 
-#: ..\plugin.py:487
+#: ..\plugin.py:509
 msgid "current platform"
 msgstr ""
 
-#: ..\plugin.py:488
+#: ..\plugin.py:510
 msgid "next"
 msgstr ""
 
-#: ..\plugin.py:524
+#: ..\plugin.py:547
 msgid "add box to favorites"
 msgstr ""
 
-#: ..\plugin.py:528
+#: ..\plugin.py:551
 msgid "Next build ends in %sh, still %s boxes ahead"
 msgstr ""
 
-#: ..\plugin.py:530
+#: ..\plugin.py:553
 msgid "Server paused, unclear how many boxes are ahead..."
 msgstr ""
 
-#: ..\plugin.py:535
+#: ..\plugin.py:558
 msgid "Image is under construction, the duration is unclear..."
 msgstr ""
 
-#: ..\plugin.py:537
+#: ..\plugin.py:560
 msgid "Image is waiting with priority, the duration is unclear..."
 msgstr ""
 
-#: ..\plugin.py:541
+#: ..\plugin.py:564
 msgid "No box found in this platform!"
 msgstr ""
 
-#: ..\plugin.py:542
+#: ..\plugin.py:565
 msgid "Nothing to do - no build cycle"
 msgstr ""
 
-#: ..\plugin.py:598
+#: ..\plugin.py:621
 msgid "Box '%s-%s' was sucessfully added to favorites!"
 msgstr ""
 
-#: ..\plugin.py:608
+#: ..\plugin.py:631
 msgid "At the moment no image is built on the platform '%s'!"
 msgstr ""
 
-#: ..\plugin.py:667 ..\plugin.py:749
+#: ..\plugin.py:693 ..\plugin.py:775
 msgid "Cancel"
 msgstr ""
 
-#: ..\plugin.py:687 ..\plugin.py:700 ..\plugin.py:707
+#: ..\plugin.py:713 ..\plugin.py:726 ..\plugin.py:733
 msgid "Model"
 msgstr ""
 
-#: ..\plugin.py:688 ..\plugin.py:701
+#: ..\plugin.py:714 ..\plugin.py:727
 msgid "Brand"
 msgstr ""
 
-#: ..\plugin.py:689 ..\plugin.py:702
+#: ..\plugin.py:715 ..\plugin.py:728
 msgid "Image"
 msgstr ""
 
-#: ..\plugin.py:690 ..\plugin.py:703
+#: ..\plugin.py:716 ..\plugin.py:729
 msgid "Version"
 msgstr ""
 
-#: ..\plugin.py:691 ..\plugin.py:704
+#: ..\plugin.py:717 ..\plugin.py:730
 msgid "Chipset"
 msgstr ""
 
-#: ..\plugin.py:708
+#: ..\plugin.py:734
 msgid "Box is OFFLINE! No current details available"
 msgstr ""
 
-#: ..\plugin.py:750
+#: ..\plugin.py:776
 msgid "Save settings"
 msgstr ""
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Preferred box architecture:"
 msgstr ""
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Specify which box architecture should be preferred when the images list will be called."
 msgstr ""
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Animation for change of platform:"
 msgstr ""
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Sets the animation speed for the carousel function when changing platforms in images list."
 msgstr ""
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Show 'NextBuild' as relative time in hours or as absolute time."
 msgstr ""
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Time indication of 'NextBuild':"
 msgstr ""
 
-#: ..\plugin.py:780
+#: ..\plugin.py:785
+msgid "Show time as local time or as standard time (UTC) from server."
+msgstr ""
+
+#: ..\plugin.py:785
+msgid "Time zone:"
+msgstr ""
+
+#: ..\plugin.py:786
+msgid "Date format:"
+msgstr ""
+
+#: ..\plugin.py:786
+msgid "Show date in desired format."
+msgstr ""
+
+#: ..\plugin.py:808
 msgid "Current overview of the OpenATV images building servers"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-03-13 19:29+0100\n"
-"PO-Revision-Date: 2024-03-13 19:29+0100\n"
+"POT-Creation-Date: 2024-04-26 10:37+0200\n"
+"PO-Revision-Date: 2024-04-26 23:05+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -16,195 +16,203 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "latest available version"
 msgstr "neuste verfügbare Version"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "oldest available version"
 msgstr "älteste verfügbare Version"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "faster"
 msgstr "schneller"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "off"
 msgstr "aus"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "slower"
 msgstr "langsamer"
 
-#: ..\plugin.py:56
+#: ..\plugin.py:57
 msgid "selected box"
 msgstr "ausgewählte Box"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "absolute time"
 msgstr "absolute Zeit"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "relative time"
 msgstr "relative Zeit"
 
-#: ..\plugin.py:186
+#: ..\plugin.py:59
+msgid "local time (this box)"
+msgstr "Lokalzeit (diese Box)"
+
+#: ..\plugin.py:59
+msgid "server time (UTC)"
+msgstr "Serverzeit (UTC)"
+
+#: ..\plugin.py:206
 msgid "Favorites"
 msgstr "Favoriten"
 
-#: ..\plugin.py:194 ..\plugin.py:522
+#: ..\plugin.py:214 ..\plugin.py:545
 msgid "remove box from favorites"
 msgstr "Box aus Favoriten entfernen"
 
-#: ..\plugin.py:195 ..\plugin.py:441
+#: ..\plugin.py:215 ..\plugin.py:462
 msgid "Images list"
 msgstr "Imageliste"
 
-#: ..\plugin.py:196 ..\plugin.py:461 ..\plugin.py:661
+#: ..\plugin.py:216 ..\plugin.py:483 ..\plugin.py:687
 msgid "Boxdetails"
 msgstr "Boxdetails"
 
-#: ..\plugin.py:197 ..\plugin.py:462 ..\plugin.py:746
+#: ..\plugin.py:217 ..\plugin.py:484 ..\plugin.py:772
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "No favorites (box, platform) set yet."
 msgstr "Noch keine Favoriten (Box, Plattform) gesetzt."
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "Please select favorite(s) in the image lists."
 msgstr "Bitte Favorit(en) in den Imagelisten auswählen."
 
-#: ..\plugin.py:354 ..\plugin.py:356
+#: ..\plugin.py:375 ..\plugin.py:377
 msgid "platform"
 msgstr "Plattform"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "boxes"
 msgstr "Boxen"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "failed"
 msgstr "fehlgeschlagen"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "last build cycle"
 msgstr "letzter Bauzyklus"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "invalid"
 msgstr "ungültig"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "unclear"
 msgstr "unklar"
 
-#: ..\plugin.py:365 ..\plugin.py:586
+#: ..\plugin.py:386 ..\plugin.py:609
 msgid "Box '%s-%s' was sucessfully removed from favorites!"
 msgstr "Box '%s-%s' wurde erfolgreich aus den Favoriten entfernt!"
 
-#: ..\plugin.py:377 ..\plugin.py:593
+#: ..\plugin.py:398 ..\plugin.py:616
 msgid "Do you really want to remove Box '%s-%s' from favorites?"
 msgstr "Wollen Sie die Box '%s-%s' wirklich aus den Favoriten entfernen?"
 
-#: ..\plugin.py:459
+#: ..\plugin.py:481
 msgid "jump to construction site"
 msgstr "springe zur Baustelle"
 
-#: ..\plugin.py:460
+#: ..\plugin.py:482
 msgid "jump to favorite(s)"
 msgstr "springe zu Favorit(en)"
 
-#: ..\plugin.py:486
+#: ..\plugin.py:508
 msgid "previous"
 msgstr "vorherige"
 
-#: ..\plugin.py:487
+#: ..\plugin.py:509
 msgid "current platform"
 msgstr "derzeitige Plattform"
 
-#: ..\plugin.py:488
+#: ..\plugin.py:510
 msgid "next"
 msgstr "nächste"
 
-#: ..\plugin.py:524
+#: ..\plugin.py:547
 msgid "add box to favorites"
 msgstr "Box zu Favoriten hinzufügen"
 
-#: ..\plugin.py:528
+#: ..\plugin.py:551
 msgid "Next build ends in %sh, still %s boxes ahead"
 msgstr "Nächstes Bauende in %sh, zuvor noch %s Box(en)"
 
-#: ..\plugin.py:530
+#: ..\plugin.py:553
 msgid "Server paused, unclear how many boxes are ahead..."
-msgstr "Server angehalten, unklar, wie viele Boxen voraus sind..."
+msgstr "Server angehalten, unklar wie viele Boxen voraus sind..."
 
-#: ..\plugin.py:535
+#: ..\plugin.py:558
 msgid "Image is under construction, the duration is unclear..."
 msgstr "Image wird gerade gebaut, die Dauer ist unklar..."
 
-#: ..\plugin.py:537
+#: ..\plugin.py:560
 msgid "Image is waiting with priority, the duration is unclear..."
 msgstr "Image wartet mit Vorrang, die Dauer ist unklar..."
 
-#: ..\plugin.py:541
+#: ..\plugin.py:564
 msgid "No box found in this platform!"
 msgstr "Keine Box in dieser Plattform gefunden!"
 
-#: ..\plugin.py:542
+#: ..\plugin.py:565
 msgid "Nothing to do - no build cycle"
 msgstr "Nichts zu tun - kein Bauzyklus"
 
-#: ..\plugin.py:598
+#: ..\plugin.py:621
 msgid "Box '%s-%s' was sucessfully added to favorites!"
 msgstr "Box '%s-%s' wurde erfolgreich zu den Favoriten hinzugefügt!"
 
-#: ..\plugin.py:608
+#: ..\plugin.py:631
 msgid "At the moment no image is built on the platform '%s'!"
 msgstr "Im Moment wird auf der Plattform '%s' kein Image gebaut!"
 
-#: ..\plugin.py:667 ..\plugin.py:749
+#: ..\plugin.py:693 ..\plugin.py:775
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ..\plugin.py:687 ..\plugin.py:700 ..\plugin.py:707
+#: ..\plugin.py:713 ..\plugin.py:726 ..\plugin.py:733
 msgid "Model"
 msgstr "Modell"
 
-#: ..\plugin.py:688 ..\plugin.py:701
+#: ..\plugin.py:714 ..\plugin.py:727
 msgid "Brand"
 msgstr "Hersteller"
 
-#: ..\plugin.py:689 ..\plugin.py:702
+#: ..\plugin.py:715 ..\plugin.py:728
 msgid "Image"
 msgstr "Image"
 
-#: ..\plugin.py:690 ..\plugin.py:703
+#: ..\plugin.py:716 ..\plugin.py:729
 msgid "Version"
 msgstr "Version"
 
-#: ..\plugin.py:691 ..\plugin.py:704
+#: ..\plugin.py:717 ..\plugin.py:730
 msgid "Chipset"
 msgstr "Chipsatz"
 
-#: ..\plugin.py:708
+#: ..\plugin.py:734
 msgid "Box is OFFLINE! No current details available"
 msgstr "Box ist OFFLINE! Keine aktuellen Details verfügbar"
 
-#: ..\plugin.py:750
+#: ..\plugin.py:776
 msgid "Save settings"
 msgstr "Einstellungen speichern"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Preferred box architecture:"
 msgstr "Bevorzugte Boxarchitektur:"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid ""
 "Specify which box architecture should be preferred when the images list will "
 "be called."
@@ -212,11 +220,11 @@ msgstr ""
 "Legen Sie fest, welche Boxarchitektur beim Aufruf der Imagelisten bevorzugt "
 "aufgerufen werden soll."
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Animation for change of platform:"
 msgstr "Animation bei Plattformwechsel:"
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid ""
 "Sets the animation speed for the carousel function when changing platforms "
 "in images list."
@@ -224,14 +232,30 @@ msgstr ""
 "Legt die Animationsgeschwindigkeit für die Karussellfunktion bei "
 "Plattformwechsel in den Imagelisten fest."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Show 'NextBuild' as relative time in hours or as absolute time."
 msgstr "Zeige 'NextBuild' als relative Zeit oder als absolute Zeit."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Time indication of 'NextBuild':"
 msgstr "Zeitangabe für 'NextBuild':"
 
-#: ..\plugin.py:780
+#: ..\plugin.py:785
+msgid "Show time as local time or as standard time (UTC) from server."
+msgstr "Zeige als Lokalzeit oder als Standardzeit (UTC) vom Server."
+
+#: ..\plugin.py:785
+msgid "Time zone:"
+msgstr "Zeitzone:"
+
+#: ..\plugin.py:786
+msgid "Date format:"
+msgstr "Datumsformat:"
+
+#: ..\plugin.py:786
+msgid "Show date in desired format."
+msgstr "Zeige im gewünschten Format."
+
+#: ..\plugin.py:808
 msgid "Current overview of the OpenATV images building servers"
 msgstr "Aktuelle Übersicht über die openATV Image-Bauserver"

--- a/po/it.po
+++ b/po/it.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-03-13 19:29+0100\n"
-"PO-Revision-Date: 2024-03-13 19:31+0100\n"
+"POT-Creation-Date: 2024-04-26 10:37+0200\n"
+"PO-Revision-Date: 2024-04-26 10:47+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Lululla\n"
 "Language: it_IT\n"
@@ -17,195 +17,203 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "latest available version"
 msgstr "ultima versione disponibile"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "oldest available version"
 msgstr "versione più vecchia disponibile"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "faster"
 msgstr "veloce"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "normal"
 msgstr "normale"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "off"
 msgstr "spento"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "slower"
 msgstr "lento"
 
-#: ..\plugin.py:56
+#: ..\plugin.py:57
 msgid "selected box"
 msgstr "box selezionato"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "absolute time"
 msgstr "tempo assoluto"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "relative time"
 msgstr "tempo relativo"
 
-#: ..\plugin.py:186
+#: ..\plugin.py:59
+msgid "local time (this box)"
+msgstr "ora locale (questa Box)"
+
+#: ..\plugin.py:59
+msgid "server time (UTC)"
+msgstr "ora del server (UTC)"
+
+#: ..\plugin.py:206
 msgid "Favorites"
 msgstr "Preferiti"
 
-#: ..\plugin.py:194 ..\plugin.py:522
+#: ..\plugin.py:214 ..\plugin.py:545
 msgid "remove box from favorites"
 msgstr "rimuovi Box da preferiti"
 
-#: ..\plugin.py:195 ..\plugin.py:441
+#: ..\plugin.py:215 ..\plugin.py:462
 msgid "Images list"
 msgstr "Lista Immagini"
 
-#: ..\plugin.py:196 ..\plugin.py:461 ..\plugin.py:661
+#: ..\plugin.py:216 ..\plugin.py:483 ..\plugin.py:687
 msgid "Boxdetails"
 msgstr "Specifiche del Box"
 
-#: ..\plugin.py:197 ..\plugin.py:462 ..\plugin.py:746
+#: ..\plugin.py:217 ..\plugin.py:484 ..\plugin.py:772
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "No favorites (box, platform) set yet."
 msgstr "Nessun preferito (box, piattaforma) ancora impostato."
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "Please select favorite(s) in the image lists."
 msgstr "Si prega di selezionare il/i preferito(i) negli elenchi di immagini."
 
-#: ..\plugin.py:354 ..\plugin.py:356
+#: ..\plugin.py:375 ..\plugin.py:377
 msgid "platform"
 msgstr "piattaforma"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "boxes"
 msgstr "box"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "failed"
 msgstr "fallito"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "last build cycle"
 msgstr "ultimo ciclo di sviluppo"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "invalid"
 msgstr "non valido"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "unclear"
 msgstr "non chiaro"
 
-#: ..\plugin.py:365 ..\plugin.py:586
+#: ..\plugin.py:386 ..\plugin.py:609
 msgid "Box '%s-%s' was sucessfully removed from favorites!"
 msgstr "Il Box '%s-%s' è stato rimosso con successo dai preferiti!"
 
-#: ..\plugin.py:377 ..\plugin.py:593
+#: ..\plugin.py:398 ..\plugin.py:616
 msgid "Do you really want to remove Box '%s-%s' from favorites?"
 msgstr "Vuoi davvero rimuovere il box '%s-%s' dai preferiti?"
 
-#: ..\plugin.py:459
+#: ..\plugin.py:481
 msgid "jump to construction site"
 msgstr "vai al sito di sviluppo"
 
-#: ..\plugin.py:460
+#: ..\plugin.py:482
 msgid "jump to favorite(s)"
 msgstr "vai al/i favorito(i)"
 
-#: ..\plugin.py:486
+#: ..\plugin.py:508
 msgid "previous"
 msgstr "precedente"
 
-#: ..\plugin.py:487
+#: ..\plugin.py:509
 msgid "current platform"
 msgstr "piattaforma attuale"
 
-#: ..\plugin.py:488
+#: ..\plugin.py:510
 msgid "next"
 msgstr "prossimo"
 
-#: ..\plugin.py:524
+#: ..\plugin.py:547
 msgid "add box to favorites"
 msgstr "aggiungi box ai preferiti"
 
-#: ..\plugin.py:528
+#: ..\plugin.py:551
 msgid "Next build ends in %sh, still %s boxes ahead"
 msgstr "La prossima build termina tra %sh, ancora %s box prima"
 
-#: ..\plugin.py:530
+#: ..\plugin.py:553
 msgid "Server paused, unclear how many boxes are ahead..."
 msgstr "Server è in pausa, non è chiaro quante box ci siano davanti..."
 
-#: ..\plugin.py:535
+#: ..\plugin.py:558
 msgid "Image is under construction, the duration is unclear..."
 msgstr "L'immagine è in costruzione, la durata non è chiara..."
 
-#: ..\plugin.py:537
+#: ..\plugin.py:560
 msgid "Image is waiting with priority, the duration is unclear..."
 msgstr "L'immagine è in attesa con priorità, la durata non è chiara..."
 
-#: ..\plugin.py:541
+#: ..\plugin.py:564
 msgid "No box found in this platform!"
 msgstr "Nessun box trovato in questa piattaforma!"
 
-#: ..\plugin.py:542
+#: ..\plugin.py:565
 msgid "Nothing to do - no build cycle"
 msgstr "Niente da fare - nessun ciclo di sviluppo"
 
-#: ..\plugin.py:598
+#: ..\plugin.py:621
 msgid "Box '%s-%s' was sucessfully added to favorites!"
 msgstr "Il Box '%s-%s' è stato aggiunto con successo ai preferiti!"
 
-#: ..\plugin.py:608
+#: ..\plugin.py:631
 msgid "At the moment no image is built on the platform '%s'!"
 msgstr "Al momento nessuna immagine è in sviluppo sulla piattaforma '%s'!"
 
-#: ..\plugin.py:667 ..\plugin.py:749
+#: ..\plugin.py:693 ..\plugin.py:775
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ..\plugin.py:687 ..\plugin.py:700 ..\plugin.py:707
+#: ..\plugin.py:713 ..\plugin.py:726 ..\plugin.py:733
 msgid "Model"
 msgstr "Modello"
 
-#: ..\plugin.py:688 ..\plugin.py:701
+#: ..\plugin.py:714 ..\plugin.py:727
 msgid "Brand"
 msgstr "Produttore"
 
-#: ..\plugin.py:689 ..\plugin.py:702
+#: ..\plugin.py:715 ..\plugin.py:728
 msgid "Image"
 msgstr "Immagine"
 
-#: ..\plugin.py:690 ..\plugin.py:703
+#: ..\plugin.py:716 ..\plugin.py:729
 msgid "Version"
 msgstr "Versione"
 
-#: ..\plugin.py:691 ..\plugin.py:704
+#: ..\plugin.py:717 ..\plugin.py:730
 msgid "Chipset"
 msgstr "Chipset"
 
-#: ..\plugin.py:708
+#: ..\plugin.py:734
 msgid "Box is OFFLINE! No current details available"
 msgstr "La scatola è OFFLINE! Non sono disponibili dettagli attuali"
 
-#: ..\plugin.py:750
+#: ..\plugin.py:776
 msgid "Save settings"
 msgstr "Salva le impostazioni"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Preferred box architecture:"
 msgstr "Architettura del box preferita:"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid ""
 "Specify which box architecture should be preferred when the images list will "
 "be called."
@@ -213,11 +221,11 @@ msgstr ""
 "Specificare quale architettura del box dovrebbe essere preferita quando "
 "verrà caricato l'elenco delle immagini."
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Animation for change of platform:"
 msgstr "Animazione per il cambio di piattaforma:"
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid ""
 "Sets the animation speed for the carousel function when changing platforms "
 "in images list."
@@ -225,14 +233,30 @@ msgstr ""
 "Imposta la velocità di animazione della funzione carosello quando si cambia "
 "piattaforma nell'elenco delle immagini."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Show 'NextBuild' as relative time in hours or as absolute time."
 msgstr "Mostra 'NextBuild' come tempo relativo in ore o come tempo assoluto."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Time indication of 'NextBuild':"
 msgstr "Indicazione del tempo di 'NextBuild':"
 
-#: ..\plugin.py:780
+#: ..\plugin.py:785
+msgid "Show time as local time or as standard time (UTC) from server."
+msgstr "Mostrare l'ora come ora locale o come ora standard (UTC) dal Server."
+
+#: ..\plugin.py:785
+msgid "Time zone:"
+msgstr "Fuso orario:"
+
+#: ..\plugin.py:786
+msgid "Date format:"
+msgstr "Formato della data:"
+
+#: ..\plugin.py:786
+msgid "Show date in desired format."
+msgstr "Visualizza la data nel formato desiderato."
+
+#: ..\plugin.py:808
 msgid "Current overview of the OpenATV images building servers"
 msgstr "Panoramica attuale dei server di creazione di immagini OpenATV"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-03-13 19:29+0100\n"
-"PO-Revision-Date: 2024-03-13 19:32+0100\n"
+"POT-Creation-Date: 2024-04-26 10:37+0200\n"
+"PO-Revision-Date: 2024-04-26 10:48+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -16,195 +16,203 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "latest available version"
 msgstr "laatst beschikbare versie"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "oldest available version"
 msgstr "oudste beschikbare versie"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "faster"
 msgstr "snel"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "normal"
 msgstr "normaal"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "off"
 msgstr "uit"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "slower"
 msgstr "langzaam"
 
-#: ..\plugin.py:56
+#: ..\plugin.py:57
 msgid "selected box"
 msgstr "geselecteerde ontvanger"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "absolute time"
 msgstr "absolute tijd"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "relative time"
 msgstr "relatieve tijd"
 
-#: ..\plugin.py:186
+#: ..\plugin.py:59
+msgid "local time (this box)"
+msgstr "lokale tijd (dit vak)"
+
+#: ..\plugin.py:59
+msgid "server time (UTC)"
+msgstr "servertijd (UTC)"
+
+#: ..\plugin.py:206
 msgid "Favorites"
 msgstr "Favorieten"
 
-#: ..\plugin.py:194 ..\plugin.py:522
+#: ..\plugin.py:214 ..\plugin.py:545
 msgid "remove box from favorites"
 msgstr "verwijder ontvanger"
 
-#: ..\plugin.py:195 ..\plugin.py:441
+#: ..\plugin.py:215 ..\plugin.py:462
 msgid "Images list"
 msgstr "Image overzicht"
 
-#: ..\plugin.py:196 ..\plugin.py:461 ..\plugin.py:661
+#: ..\plugin.py:216 ..\plugin.py:483 ..\plugin.py:687
 msgid "Boxdetails"
 msgstr "Details"
 
-#: ..\plugin.py:197 ..\plugin.py:462 ..\plugin.py:746
+#: ..\plugin.py:217 ..\plugin.py:484 ..\plugin.py:772
 msgid "Settings"
 msgstr "Instellingen"
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "No favorites (box, platform) set yet."
 msgstr "Nog geen favoriet ingesteld."
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "Please select favorite(s) in the image lists."
 msgstr "Favoriet(en) selecteren in het Image overzicht."
 
-#: ..\plugin.py:354 ..\plugin.py:356
+#: ..\plugin.py:375 ..\plugin.py:377
 msgid "platform"
 msgstr "platform"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "boxes"
 msgstr "ontvangers"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "failed"
 msgstr "mislukt"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "last build cycle"
 msgstr "laatste build cycle"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "invalid"
 msgstr "ongeldig"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "unclear"
 msgstr "onduidelijk"
 
-#: ..\plugin.py:365 ..\plugin.py:586
+#: ..\plugin.py:386 ..\plugin.py:609
 msgid "Box '%s-%s' was sucessfully removed from favorites!"
 msgstr "%s-%s is verwijderd uit de favorieten!"
 
-#: ..\plugin.py:377 ..\plugin.py:593
+#: ..\plugin.py:398 ..\plugin.py:616
 msgid "Do you really want to remove Box '%s-%s' from favorites?"
 msgstr "Wilt u de ontvanger '%s-%s' verwijderen uit de favorieten?"
 
-#: ..\plugin.py:459
+#: ..\plugin.py:481
 msgid "jump to construction site"
 msgstr "ontvanger die nu wordt gebouwd"
 
-#: ..\plugin.py:460
+#: ..\plugin.py:482
 msgid "jump to favorite(s)"
 msgstr "naar favoriet(en)"
 
-#: ..\plugin.py:486
+#: ..\plugin.py:508
 msgid "previous"
 msgstr "vorige"
 
-#: ..\plugin.py:487
+#: ..\plugin.py:509
 msgid "current platform"
 msgstr "huidig platform"
 
-#: ..\plugin.py:488
+#: ..\plugin.py:510
 msgid "next"
 msgstr "volgende"
 
-#: ..\plugin.py:524
+#: ..\plugin.py:547
 msgid "add box to favorites"
 msgstr "aan favorieten toevoegen"
 
-#: ..\plugin.py:528
+#: ..\plugin.py:551
 msgid "Next build ends in %sh, still %s boxes ahead"
 msgstr "Volgende build eindigt %sh, nog %s ontvanger(s) te gaan"
 
-#: ..\plugin.py:530
+#: ..\plugin.py:553
 msgid "Server paused, unclear how many boxes are ahead..."
 msgstr "Server gepauzeerd, onduidelijk hoeveel dozen er nog komen..."
 
-#: ..\plugin.py:535
+#: ..\plugin.py:558
 msgid "Image is under construction, the duration is unclear..."
 msgstr "Image wordt nog gebouwd, de duur is onbekend..."
 
-#: ..\plugin.py:537
+#: ..\plugin.py:560
 msgid "Image is waiting with priority, the duration is unclear..."
 msgstr "Image wacht met voorrang, de duur is onduidelijk..."
 
-#: ..\plugin.py:541
+#: ..\plugin.py:564
 msgid "No box found in this platform!"
 msgstr "Geen ontvanger gevonden voor dit platform!"
 
-#: ..\plugin.py:542
+#: ..\plugin.py:565
 msgid "Nothing to do - no build cycle"
 msgstr "Been gegevens - Geen build cycle"
 
-#: ..\plugin.py:598
+#: ..\plugin.py:621
 msgid "Box '%s-%s' was sucessfully added to favorites!"
 msgstr "%s-%s is toegevoegd aan de favorieten!"
 
-#: ..\plugin.py:608
+#: ..\plugin.py:631
 msgid "At the moment no image is built on the platform '%s'!"
 msgstr "Op dit moment wordt er geen image gebouwd voor het platform '%s'!"
 
-#: ..\plugin.py:667 ..\plugin.py:749
+#: ..\plugin.py:693 ..\plugin.py:775
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ..\plugin.py:687 ..\plugin.py:700 ..\plugin.py:707
+#: ..\plugin.py:713 ..\plugin.py:726 ..\plugin.py:733
 msgid "Model"
 msgstr "Model"
 
-#: ..\plugin.py:688 ..\plugin.py:701
+#: ..\plugin.py:714 ..\plugin.py:727
 msgid "Brand"
 msgstr "Fabrikant"
 
-#: ..\plugin.py:689 ..\plugin.py:702
+#: ..\plugin.py:715 ..\plugin.py:728
 msgid "Image"
 msgstr "Image"
 
-#: ..\plugin.py:690 ..\plugin.py:703
+#: ..\plugin.py:716 ..\plugin.py:729
 msgid "Version"
 msgstr "Versie"
 
-#: ..\plugin.py:691 ..\plugin.py:704
+#: ..\plugin.py:717 ..\plugin.py:730
 msgid "Chipset"
 msgstr "Chipset"
 
-#: ..\plugin.py:708
+#: ..\plugin.py:734
 msgid "Box is OFFLINE! No current details available"
 msgstr "Box is OFFLINE! Geen actuele gegevens beschikbaar"
 
-#: ..\plugin.py:750
+#: ..\plugin.py:776
 msgid "Save settings"
 msgstr "Bevestigen"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Preferred box architecture:"
 msgstr "Voorkeur voor boxarchitectuur:"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid ""
 "Specify which box architecture should be preferred when the images list will "
 "be called."
@@ -212,11 +220,11 @@ msgstr ""
 "A.u.b. opgeven welk platform uw voorkeur heeft wanneer het image overzicht "
 "wordt geopend."
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Animation for change of platform:"
 msgstr "Animatie bij het wisselen van een platform:"
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid ""
 "Sets the animation speed for the carousel function when changing platforms "
 "in images list."
@@ -224,14 +232,30 @@ msgstr ""
 "De animatie snelheid instellen wanneer er van platform wordt gewisseld in "
 "image overzicht."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Show 'NextBuild' as relative time in hours or as absolute time."
 msgstr "Toon 'NextBuild' als relatieve tijd in uren of als absolute tijd."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Time indication of 'NextBuild':"
 msgstr "Tijdsaanduiding van 'NextBuild':"
 
-#: ..\plugin.py:780
+#: ..\plugin.py:785
+msgid "Show time as local time or as standard time (UTC) from server."
+msgstr "Toon de tijd als lokale tijd of als standaardtijd (UTC) van de Server."
+
+#: ..\plugin.py:785
+msgid "Time zone:"
+msgstr "Tijdzone:"
+
+#: ..\plugin.py:786
+msgid "Date format:"
+msgstr "Datum formaat:"
+
+#: ..\plugin.py:786
+msgid "Show date in desired format."
+msgstr "Datum in het gewenste formaat weergeven."
+
+#: ..\plugin.py:808
 msgid "Current overview of the OpenATV images building servers"
 msgstr "Actueel overzicht van de openATV image bouwservers"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-03-13 19:29+0100\n"
-"PO-Revision-Date: 2024-03-13 19:32+0100\n"
+"POT-Creation-Date: 2024-04-26 10:37+0200\n"
+"PO-Revision-Date: 2024-04-26 10:49+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: endriu\n"
 "Language: pl\n"
@@ -16,195 +16,203 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "latest available version"
 msgstr "najnowsza dostępna wersja"
 
-#: ..\plugin.py:51
+#: ..\plugin.py:52
 msgid "oldest available version"
 msgstr "najstarsza dostępna wersja"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "faster"
 msgstr "szybciej"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "normal"
 msgstr "normalnie"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "off"
 msgstr "wyłącz"
 
-#: ..\plugin.py:55
+#: ..\plugin.py:56
 msgid "slower"
 msgstr "wolniej"
 
-#: ..\plugin.py:56
+#: ..\plugin.py:57
 msgid "selected box"
 msgstr "wybrany Box"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "absolute time"
 msgstr "czas bezwzględny"
 
-#: ..\plugin.py:57
+#: ..\plugin.py:58
 msgid "relative time"
 msgstr "czas względny"
 
-#: ..\plugin.py:186
+#: ..\plugin.py:59
+msgid "local time (this box)"
+msgstr "czas lokalny (to pole)"
+
+#: ..\plugin.py:59
+msgid "server time (UTC)"
+msgstr "czas serwera (UTC)"
+
+#: ..\plugin.py:206
 msgid "Favorites"
 msgstr "Ulubione"
 
-#: ..\plugin.py:194 ..\plugin.py:522
+#: ..\plugin.py:214 ..\plugin.py:545
 msgid "remove box from favorites"
 msgstr "usuń Box z ulubionych"
 
-#: ..\plugin.py:195 ..\plugin.py:441
+#: ..\plugin.py:215 ..\plugin.py:462
 msgid "Images list"
 msgstr "Lista obrazów"
 
-#: ..\plugin.py:196 ..\plugin.py:461 ..\plugin.py:661
+#: ..\plugin.py:216 ..\plugin.py:483 ..\plugin.py:687
 msgid "Boxdetails"
 msgstr "Szczegóły Boxa"
 
-#: ..\plugin.py:197 ..\plugin.py:462 ..\plugin.py:746
+#: ..\plugin.py:217 ..\plugin.py:484 ..\plugin.py:772
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "No favorites (box, platform) set yet."
 msgstr "Nie ustawiono jeszcze ulubionych (box, platforma)."
 
-#: ..\plugin.py:292
+#: ..\plugin.py:313
 msgid "Please select favorite(s) in the image lists."
 msgstr "Wybierz ulubione z list obrazów."
 
-#: ..\plugin.py:354 ..\plugin.py:356
+#: ..\plugin.py:375 ..\plugin.py:377
 msgid "platform"
 msgstr "platforma"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "boxes"
 msgstr "boxy"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "failed"
 msgstr "błąd"
 
-#: ..\plugin.py:354 ..\plugin.py:356 ..\plugin.py:539
+#: ..\plugin.py:375 ..\plugin.py:377 ..\plugin.py:562
 msgid "last build cycle"
 msgstr "ostatni cykl budowy"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "invalid"
 msgstr "nieważny"
 
-#: ..\plugin.py:356
+#: ..\plugin.py:377
 msgid "unclear"
 msgstr "niejasny"
 
-#: ..\plugin.py:365 ..\plugin.py:586
+#: ..\plugin.py:386 ..\plugin.py:609
 msgid "Box '%s-%s' was sucessfully removed from favorites!"
 msgstr "Box „%s-%s” został pomyślnie usunięty z ulubionych!"
 
-#: ..\plugin.py:377 ..\plugin.py:593
+#: ..\plugin.py:398 ..\plugin.py:616
 msgid "Do you really want to remove Box '%s-%s' from favorites?"
 msgstr "Na pewno chcesz usunąć Box „%s-%s” z ulubionych?"
 
-#: ..\plugin.py:459
+#: ..\plugin.py:481
 msgid "jump to construction site"
 msgstr "skocz do strony budowy"
 
-#: ..\plugin.py:460
+#: ..\plugin.py:482
 msgid "jump to favorite(s)"
 msgstr "skocz do ulubionych"
 
-#: ..\plugin.py:486
+#: ..\plugin.py:508
 msgid "previous"
 msgstr "poprzedni"
 
-#: ..\plugin.py:487
+#: ..\plugin.py:509
 msgid "current platform"
 msgstr "aktualna platforma"
 
-#: ..\plugin.py:488
+#: ..\plugin.py:510
 msgid "next"
 msgstr "następny"
 
-#: ..\plugin.py:524
+#: ..\plugin.py:547
 msgid "add box to favorites"
 msgstr "dodaj Box do ulubionych"
 
-#: ..\plugin.py:528
+#: ..\plugin.py:551
 msgid "Next build ends in %sh, still %s boxes ahead"
 msgstr "Następna kompilacja kończy się za %sh, nadal %s boxy wcześniej"
 
-#: ..\plugin.py:530
+#: ..\plugin.py:553
 msgid "Server paused, unclear how many boxes are ahead..."
 msgstr "Serwer wstrzymany, nie wiadomo ile skrzynek przed nami..."
 
-#: ..\plugin.py:535
+#: ..\plugin.py:558
 msgid "Image is under construction, the duration is unclear..."
 msgstr "Image jest w budowie, czas trwania jest niejasny..."
 
-#: ..\plugin.py:537
+#: ..\plugin.py:560
 msgid "Image is waiting with priority, the duration is unclear..."
 msgstr "Image czeka z priorytetem, czas trwania jest niejasny..."
 
-#: ..\plugin.py:541
+#: ..\plugin.py:564
 msgid "No box found in this platform!"
 msgstr "Nie znaleziono boxa na tej platformie!"
 
-#: ..\plugin.py:542
+#: ..\plugin.py:565
 msgid "Nothing to do - no build cycle"
 msgstr "Nic do zrobienia - brak cyklu budowania"
 
-#: ..\plugin.py:598
+#: ..\plugin.py:621
 msgid "Box '%s-%s' was sucessfully added to favorites!"
 msgstr "Box „%s-%s” został pomyślnie dodany do ulubionych!"
 
-#: ..\plugin.py:608
+#: ..\plugin.py:631
 msgid "At the moment no image is built on the platform '%s'!"
 msgstr "W tej chwili żaden obraz nie jest tworzony na platformie „%s”!"
 
-#: ..\plugin.py:667 ..\plugin.py:749
+#: ..\plugin.py:693 ..\plugin.py:775
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ..\plugin.py:687 ..\plugin.py:700 ..\plugin.py:707
+#: ..\plugin.py:713 ..\plugin.py:726 ..\plugin.py:733
 msgid "Model"
 msgstr "Model"
 
-#: ..\plugin.py:688 ..\plugin.py:701
+#: ..\plugin.py:714 ..\plugin.py:727
 msgid "Brand"
 msgstr "Producent"
 
-#: ..\plugin.py:689 ..\plugin.py:702
+#: ..\plugin.py:715 ..\plugin.py:728
 msgid "Image"
 msgstr "Obraz"
 
-#: ..\plugin.py:690 ..\plugin.py:703
+#: ..\plugin.py:716 ..\plugin.py:729
 msgid "Version"
 msgstr "Wersja"
 
-#: ..\plugin.py:691 ..\plugin.py:704
+#: ..\plugin.py:717 ..\plugin.py:730
 msgid "Chipset"
 msgstr "Chipset"
 
-#: ..\plugin.py:708
+#: ..\plugin.py:734
 msgid "Box is OFFLINE! No current details available"
 msgstr "Box jest OFFLINE! Brak aktualnych szczegółów"
 
-#: ..\plugin.py:750
+#: ..\plugin.py:776
 msgid "Save settings"
 msgstr "Zapisz ustawienia"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid "Preferred box architecture:"
 msgstr "Preferowana architektura pudełka:"
 
-#: ..\plugin.py:756
+#: ..\plugin.py:782
 msgid ""
 "Specify which box architecture should be preferred when the images list will "
 "be called."
@@ -212,11 +220,11 @@ msgstr ""
 "Określa, która architektura pudełka powinna być preferowana podczas "
 "wywoływania listy obrazów."
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid "Animation for change of platform:"
 msgstr "Animacja w czasie zmiany platformy:"
 
-#: ..\plugin.py:757
+#: ..\plugin.py:783
 msgid ""
 "Sets the animation speed for the carousel function when changing platforms "
 "in images list."
@@ -224,15 +232,33 @@ msgstr ""
 "Ustawia prędkość animacji dla funkcji karuzeli podczas zmiany platform na "
 "liście obrazów."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Show 'NextBuild' as relative time in hours or as absolute time."
 msgstr ""
 "Pokaż \"NextBuild\" jako czas względny w godzinach lub jako czas bezwzględny."
 
-#: ..\plugin.py:758
+#: ..\plugin.py:784
 msgid "Time indication of 'NextBuild':"
 msgstr "Wskazanie czasu \"NextBuild\":"
 
-#: ..\plugin.py:780
+#: ..\plugin.py:785
+msgid "Show time as local time or as standard time (UTC) from server."
+msgstr ""
+"Wyświetlanie czasu jako czasu lokalnego lub czasu standardowego (UTC) z "
+"serwera."
+
+#: ..\plugin.py:785
+msgid "Time zone:"
+msgstr "Strefa czasowa:"
+
+#: ..\plugin.py:786
+msgid "Date format:"
+msgstr "Format daty:"
+
+#: ..\plugin.py:786
+msgid "Show date in desired format."
+msgstr "Wyświetlanie daty w wybranym formacie."
+
+#: ..\plugin.py:808
 msgid "Current overview of the OpenATV images building servers"
 msgstr "Bieżący przegląd serwerów do tworzenia obrazów OATV"

--- a/src/Buildstatus.py
+++ b/src/Buildstatus.py
@@ -119,7 +119,7 @@ class Buildstatus():
 			self.htmldict = self.htmlparse(htmldata)  # complete dict of all platform boxes
 		else:
 			self.htmldict = None
-			self.error = "[%s] ERROR in module 'getpage': htmldata is None." % MODULE_NAME
+			self.error = "[%s] ERROR in module 'createdict': htmldata is None." % MODULE_NAME
 		if callback:
 			if not self.error:
 				print("[%s] buildservers successfully accessed..." % MODULE_NAME)


### PR DESCRIPTION
- new selection option “Time zone” (local time [setting of box] or server time [UTC])”
- new selection option “Date format” (all possible ways of displaying the date)
- SyncTime, BuildTime, CycleTime and NextBuild are now displayed in minutes (e.g. previously “08:31”, now “9 min”)
- some tiny code deatils corrected
- all translations modified accordingly