### PR TITLE
[OpenATVstatus] update 2.7

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -63,7 +63,7 @@ config.plugins.OpenATVstatus.favboxes = ConfigText(default="", fixed_size=False)
 
 
 class ATVglobs():
-	VERSION = "V2.6"
+	VERSION = "V2.7"
 	MODULE_NAME = __name__.split(".")[-2]
 	FAVLIST = [tuple(x.strip() for x in item.replace("(", "").replace(")", "").split(",")) for item in config.plugins.OpenATVstatus.favboxes.value.split(";")] if config.plugins.OpenATVstatus.favboxes.value else []
 	PICURL = "https://raw.githubusercontent.com/oe-alliance/remotes/master/boxes/"
@@ -532,7 +532,7 @@ class ATVimageslist(Screen, ATVglobs):
 				color = 0xFDFf00 if [item for item in self.FAVLIST if item == (boxname, self.currplat)] else palette.get(bd["BuildStatus"], 0xB0B0B0)
 				buildtime = self.roundMinutes(bd["BuildTime"].strip())
 				synctime = self.roundMinutes(bd["SyncTime"].strip())
-				menulist.append(tuple([boxname, bd["BuildStatus"], self.fmtDateTime(bd["StartBuild"]), self.fmtDateTime(bd["StartFeedSync"]), self.fmtDateTime(bd["EndBuild"]), synctime, buildtime, color]))
+				menulist.append(tuple([bd["No"],boxname, bd["BuildStatus"], self.fmtDateTime(bd["StartBuild"]), self.fmtDateTime(bd["StartFeedSync"]), self.fmtDateTime(bd["EndBuild"]), synctime, buildtime, color]))
 			self["menu"].updateList(menulist)
 			self.boxlist = boxlist
 		if self.currbox:

--- a/src/skin_HD.xml
+++ b/src/skin_HD.xml
@@ -70,7 +70,8 @@
 		<ePixmap position="1193,33" size="30,30" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/OpenATVstatus/icons/bouquet_HD.png" alphatest="blend" zPosition="1" />
 		<widget name="curr_date" position="1100,6" size="120,30" font="Regular;20" halign="right" valign="top" />
 		<eLabel position="10,70" size="1220,30" backgroundColor="grey" zPosition="-1" />
-		<eLabel text="BoxName" position="10,70" size="1903,30" font="Regular;20" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="Nr" position="10,70" size="35,30" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="BoxName" position="55,70" size="190,30" font="Regular;20" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
 		<eLabel text="BuildStatus" position="200,70" size="110,30" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
 		<eLabel text="StartBuild" position="310,70" size="230,30" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
 		<eLabel text="StartFeedSync" position="540,70" size="230,30" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
@@ -80,13 +81,14 @@
 		<widget source="menu" render="Listbox" position="10,100" size="1220,494" scrollbarMode="showOnDemand">
 			<convert type="TemplatedMultiContent">
 				{"template": [
-				MultiContentEntryText(pos=(0,0), size=(190,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER, text=0),  # BoxName
-				MultiContentEntryText(pos=(190,0), size=(110,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=1),  # BuildStatus
-				MultiContentEntryText(pos=(300,0), size=(230,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=2),  # StartBuild
-				MultiContentEntryText(pos=(530,0), size=(230,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=3),  # StartFeedSync
-				MultiContentEntryText(pos=(760,0), size=(230,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=4),  # EndBuild
-				MultiContentEntryText(pos=(990,0), size=(100,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=5),  # SyncTime
-				MultiContentEntryText(pos=(1100,0), size=(100,26), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=6)  # BuildTime
+				MultiContentEntryText(pos=(0,0), size=(35,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=0),  # No
+				MultiContentEntryText(pos=(45,0), size=(190,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER, text=1),  # BoxName
+				MultiContentEntryText(pos=(190,0), size=(110,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=2),  # BuildStatus
+				MultiContentEntryText(pos=(300,0), size=(230,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=3),  # StartBuild
+				MultiContentEntryText(pos=(530,0), size=(230,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=4),  # StartFeedSync
+				MultiContentEntryText(pos=(760,0), size=(230,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=5),  # EndBuild
+				MultiContentEntryText(pos=(990,0), size=(100,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=6),  # SyncTime
+				MultiContentEntryText(pos=(1100,0), size=(100,26), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=7)  # BuildTime
 				],
 				"fonts": [gFont("Regular",20), gFont("Regular",12)],
 				"itemHeight":26
@@ -94,8 +96,8 @@
 			</convert>
 		</widget>
 		<eLabel position="10,594" size="1220,30" backgroundColor="grey" zPosition="-1" />
-		<widget name="boxinfo" position="10,594" size="570,28" font="Regular;20" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<widget name="platinfo" position="580,594" size="650,28" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<widget name="boxinfo" position="15,594" size="570,28" font="Regular;20" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<widget name="platinfo" position="585,594" size="640,28" font="Regular;20" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
 		<eLabel name="red" position="36,643" size="6,43" backgroundColor="red" zPosition="1" />
 		<eLabel name="green" position="316,643" size="6,43" backgroundColor="green" zPosition="1" />
 		<eLabel name="yellow" position="596,643" size="6,43" backgroundColor="yellow" zPosition="1" />

--- a/src/skin_fHD.xml
+++ b/src/skin_fHD.xml
@@ -55,7 +55,7 @@
 		<widget name="key_menu" position="1044,925" size="255,42" font="Regular;30" halign="left" foregroundColor="grey" />
 	</screen>
 
-	<screen name="ATVimageslist" position="center,center" size="1860,1035" title="" flags="wfNoBorder">
+	<screen name="ATVimageslist" position="center,center" size="1900,1035" title="" flags="wfNoBorder">
 		<ePixmap position="15,15" size="450,75" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/OpenATVstatus/icons/openATV_fHD.png" alphatest="blend" zPosition="1" />
 		<widget name="version" position="435,60" size="60,30" font="Regular;24" halign="left" valign="center" />
 		<widget source="Title" render="Label" position="540,25" size="255,72" font="Regular;54" halign="left" valign="bottom" />
@@ -69,33 +69,35 @@
 		<widget name="next_plat" position="1545,39" size="255,54" font="Regular;36" halign="left" valign="bottom" />
 		<ePixmap position="1790,50" size="45,45" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/OpenATVstatus/icons/bouquet_fHD.png" alphatest="blend" zPosition="1" />
 		<widget name="curr_date" position="1650,9" size="180,45" font="Regular;30" halign="right" valign="top" />
-		<eLabel position="15,105" size="1830,45" backgroundColor="grey" zPosition="-1" />
-		<eLabel text="BoxName" position="15,105" size="2855,45" font="Regular;30" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="BuildStatus" position="300,105" size="165,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="StartBuild" position="465,105" size="345,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="StartFeedSync" position="810,105" size="345,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="EndBuild" position="1155,105" size="345,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="SyncTime" position="1500,105" size="150,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<eLabel text="BuildTime" position="1665,105" size="150,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<widget source="menu" render="Listbox" position="15,150" size="1830,741" scrollbarMode="showOnDemand">
+		<eLabel position="15,105" size="1870,45" backgroundColor="grey" zPosition="-1" />
+		<eLabel text="Nr" position="15,105" size="50,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="BoxName" position="85,105" size="285,45" font="Regular;30" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="BuildStatus" position="355,105" size="165,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="StartBuild" position="520,105" size="340,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="StartFeedSync" position="860,105" size="340,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="EndBuild" position="1205,105" size="340,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="SyncTime" position="1550,105" size="150,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel text="BuildTime" position="1705,105" size="150,45" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<widget source="menu" render="Listbox" position="15,150" size="1870,741" scrollbarMode="showOnDemand">
 			<convert type="TemplatedMultiContent">
 				{"template": [
-				MultiContentEntryText(pos=(0,0), size=(285,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER, text=0),  # BoxName
-				MultiContentEntryText(pos=(285,0), size=(165,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=1),  # BuildStatus
-				MultiContentEntryText(pos=(450,0), size=(345,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=2),  # StartBuild
-				MultiContentEntryText(pos=(795,0), size=(345,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=3),  # StartFeedSync
-				MultiContentEntryText(pos=(1140,0), size=(345,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=4),  # EndBuild
-				MultiContentEntryText(pos=(1485,0), size=(150,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=5),  # SyncTime
-				MultiContentEntryText(pos=(1650,0), size=(150,39), font=0, color=MultiContentTemplateColor(7), color_sel=MultiContentTemplateColor(7), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=6)  # BuildTime
+				MultiContentEntryText(pos=(0,0), size=(50,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=0),  # No
+				MultiContentEntryText(pos=(70,0), size=(285,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER, text=1),  # BoxName
+				MultiContentEntryText(pos=(340,0), size=(165,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=2),  # BuildStatus
+				MultiContentEntryText(pos=(505,0), size=(340,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=3),  # StartBuild
+				MultiContentEntryText(pos=(845,0), size=(340,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=4),  # StartFeedSync
+				MultiContentEntryText(pos=(1190,0), size=(340,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=5),  # EndBuild
+				MultiContentEntryText(pos=(1535,0), size=(150,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=6),  # SyncTime
+				MultiContentEntryText(pos=(1690,0), size=(150,39), font=0, color=MultiContentTemplateColor(8), color_sel=MultiContentTemplateColor(8), flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=7)  # BuildTime
 				],
 				"fonts": [gFont("Regular",31), gFont("Regular",19)],
 				"itemHeight":39
 				}
 			</convert>
 		</widget>
-		<eLabel position="15,891" size="1830,45" backgroundColor="grey" zPosition="-1" />
-		<widget name="boxinfo" position="15,891" size="855,42" font="Regular;30" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
-		<widget name="platinfo" position="870,891" size="975,42" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<eLabel position="15,891" size="1870,45" backgroundColor="grey" zPosition="-1" />
+		<widget name="boxinfo" position="20,891" size="855,42" font="Regular;30" halign="left" valign="center" foregroundColor="black" backgroundColor="grey" />
+		<widget name="platinfo" position="875,891" size="1005,42" font="Regular;30" halign="right" valign="center" foregroundColor="black" backgroundColor="grey" />
 		<eLabel name="red" position="54,965" size="9,65" backgroundColor="red" zPosition="1" />
 		<eLabel name="green" position="474,965" size="9,65" backgroundColor="green" zPosition="1" />
 		<eLabel name="yellow" position="894,965" size="9,65" backgroundColor="yellow" zPosition="1" />


### PR DESCRIPTION
- add column No from buildstatus page to ATVimageslist screen
- more space to the edge for the boxinfo and platinfo widgets

![image](https://github.com/user-attachments/assets/a318ce19-d090-42b6-b63a-48ad88a11f18)


